### PR TITLE
fix: resolve compiler warnings by making binary exponentiation functions public

### DIFF
--- a/src/lib/Binary_Exponentiation.mbt
+++ b/src/lib/Binary_Exponentiation.mbt
@@ -20,7 +20,7 @@
 ///   inspect!(bin_pow(15, 20), content="4664335276710460609")
 /// }
 /// ```
-fn bin_pow(x : Int64, y : Int64) -> Int64 {
+pub fn bin_pow(x : Int64, y : Int64) -> Int64 {
   let mut res : Int64 = 1
   let mut a : Int64 = x
   let mut n : Int64 = y
@@ -64,7 +64,7 @@ fn bin_pow(x : Int64, y : Int64) -> Int64 {
 ///   let _ = bin_pow_mod(2, 3, 0)
 /// }
 /// ```
-fn bin_pow_mod(x : Int64, y : Int64, z : Int64) -> Int64 {
+pub fn bin_pow_mod(x : Int64, y : Int64, z : Int64) -> Int64 {
   let mut res : Int64 = 1
   let mut a : Int64 = x
   let mut n : Int64 = y

--- a/src/lib/Binary_Exponentiation.mbt
+++ b/src/lib/Binary_Exponentiation.mbt
@@ -1,4 +1,4 @@
-/// Calculates the power of a number using binary exponentiation algorithm, also
+///| Calculates the power of a number using binary exponentiation algorithm, also
 /// known as fast exponentiation.
 ///
 /// Parameters:
@@ -34,7 +34,7 @@ fn bin_pow(x : Int64, y : Int64) -> Int64 {
   res
 }
 
-/// Calculates the modular exponentiation using binary exponentiation algorithm
+///| Calculates the modular exponentiation using binary exponentiation algorithm
 /// (also known as fast exponentiation). This is particularly useful for
 /// computing large powers in modular arithmetic without causing overflow.
 ///

--- a/src/lib/lib.mbti
+++ b/src/lib/lib.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "CMoonBack/Binary-Exponentiation/lib"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/lib/lib.mbti
+++ b/src/lib/lib.mbti
@@ -2,6 +2,9 @@
 package "CMoonBack/Binary-Exponentiation/lib"
 
 // Values
+fn bin_pow(Int64, Int64) -> Int64
+
+fn bin_pow_mod(Int64, Int64, Int64) -> Int64
 
 // Errors
 

--- a/src/main/main.mbt
+++ b/src/main/main.mbt
@@ -1,3 +1,4 @@
+///|
 fn main {
   println("123")
 }

--- a/src/main/main.mbti
+++ b/src/main/main.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "CMoonBack/Binary-Exponentiation/main"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

Fixed two compiler warnings about unused functions:
- bin_pow: Binary exponentiation function
- bin_pow_mod: Modular binary exponentiation function

These functions are now properly exported as public API functions in the library interface,
making them available for external use and resolving the "unused function" warnings.

Changes:
- Added 'pub' keyword to both functions in Binary_Exponentiation.mbt
- Updated lib.mbti to export the function signatures